### PR TITLE
Fixes #9. Move to renamed FMS

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,15 +9,15 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_cmake.git
 local_path = ./@cmake
-tag = v1.0.9
+tag = v1.0.10
 externals = Externals.cfg
 protocol = git
 
 [FMS]
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
-local_path = ./src/Shared/@GFDL_fms
-tag = geos/orphan/v1.0.1
+local_path = ./src/Shared/@FMS
+tag = geos/orphan/v1.0.2
 protocol = git
 
 [GMAO_Shared]
@@ -32,7 +32,7 @@ sparse = ../../../config/GMAO_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./src/Components/@FVdycoreCubed_GridComp
-tag = v1.0.6
+tag = v1.0.7
 externals = Externals.cfg
 protocol = git
 

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -1,2 +1,3 @@
 /@MAPL
-/@GFDL_fms
+/@FMS
+/@GMAO_Shared

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -3,4 +3,4 @@ esma_add_subdirectories (
   @GMAO_Shared
   )
 
-add_subdirectory (@GFDL_fms GFDL_fms_r4)
+add_subdirectory (@FMS fms_r4)


### PR DESCRIPTION
This has a few changes:

1. Update `Externals.cfg` to point to the newer releases that have
renamed-FMS support (from `GEOSgcm`)

2. Fix CMake to use new name: `@GFDL_fms` => `@FMS`

3. Fix `.gitignore` to use new name

4. Add `@GMAO_Shared` to `.gitignore`