### PR TITLE
Update Externals.cfg and sparse

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -17,14 +17,14 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/orphan/v1.0.2
+tag = geos/orphan/v1.0.3
 protocol = git
 
 [GMAO_Shared]
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.12
+tag = v1.0.13
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 
@@ -32,7 +32,7 @@ sparse = ../../../config/GMAO_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./src/Components/@FVdycoreCubed_GridComp
-tag = v1.0.7
+tag = v1.0.8
 externals = Externals.cfg
 protocol = git
 
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
-tag = v1.1.9
+tag = v1.1.12
 protocol = git
 
 [externals_description]

--- a/config/GMAO_Shared.sparse
+++ b/config/GMAO_Shared.sparse
@@ -4,6 +4,9 @@
 /GMAO_mpeu
 /GMAO_gfio
 /GEOS_Shared
+/GMAO_etc
+/GEOS_Util
+/GMAO_perllib
 /CMakeLists.txt
 /LICENSE.md
 /README.md


### PR DESCRIPTION
First, bring this fixture up to date with stable GCM.

Then, do not sparse out:

* GMAO_etc
* GEOS_Util
* GMAO_perllib

as they are needed by Bill'l FV3 benchmarking scripts.