### PR TITLE
Add option to use microphysics from FV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ add_definitions(-Dsys${CMAKE_SYSTEM_NAME} -DESMA64)
 add_definitions(${MPI_Fortran_COMPILE_FLAGS})
 include_directories(${MPI_Fortran_INCLUDE_PATH})
 
+# For GEOSfvdycore, we need to use the GFDL from fvdycore
+option(USE_GFDL_MP_FROM_FV "Use GFDL microphysics from fvdycore" ON)
+
 # Recursively build source tree
 add_subdirectory (@env)
 add_subdirectory (src)


### PR DESCRIPTION
This PR adds an `option()` to use the GFDL microphysics from FV only when positively asked for. This is needed do to these PRs:

https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/pull/42
https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/119

which (for the GCM) do not compile the GFDL microphysics in FV in favor of the one in GEOSmoist_GridComp.