### PR TITLE
Updates for 1.4.0 Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
 
   ifort-large:
     docker:
-      - image: gmao/ubuntu20-geos-env:v6.2.8-intelmpi_2021.2.0-intel_2021.2.0
+      - image: gmao/ubuntu20-geos-env:v6.2.8-intelmpi_2021.3.0-intel_2021.3.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# Global Editor Config for MAPL
+#
+# This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+#
+# Top level editor config.
+root = true
+
+# Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML format, 2 spaces
+[{*.yaml,*.yml}]
+indent_style = space
+indent_size = 2
+
+# CMake (from KitWare: https://github.com/Kitware/CMake/blob/master/.editorconfig)
+[{CMakeLists.txt,*.cmake,*.rst}]
+indent_style = space
+indent_size = 2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,13 @@
 # The FV3 Team owns all
 * @GEOS-ESM/fv3-gatekeepers
 
-# The CMake Team should know/approve these
-/.github/    @GEOS-ESM/cmake-team
-/.circleci/  @GEOS-ESM/cmake-team
-/.codebuild/ @GEOS-ESM/cmake-team
+# The FV3 gatekeepers and CMake Team should know/approve these
+/.github/    @GEOS-ESM/cmake-team @GEOS-ESM/fv3-gatekeepers
+/.circleci/  @GEOS-ESM/cmake-team @GEOS-ESM/fv3-gatekeepers
+/.codebuild/ @GEOS-ESM/cmake-team @GEOS-ESM/fv3-gatekeepers
 
-# The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team
+# The GEOS CMake Team should be notified about changes to the CMakeLists.txt files in this repository
+CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/fv3-gatekeepers
 
+# The GEOS CMake Team should be notified about and approve config changes
+/config/ @GEOS-ESM/cmake-team @GEOS-ESM/fv3-gatekeepers

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -1,0 +1,23 @@
+name: "Enforce Changelog"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabels: 'Skip Changelog,0 diff trivial,automatic'
+        missingUpdateErrorMessage: >
+            No update to CHANGELOG.md found! Please add a changelog
+            entry to it describing your change.  Please note that the
+            keepachangelog (https://keepachangelog.com) format is
+            used. If your change is very trivial not applicable for a
+            changelog entry, add a 'Skip Changelog' label to the pull
+            request to skip the changelog enforcer.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,239 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [1.4.0] - 2021-12-21
+
+### Changed
+
+- Updates to `components.yaml` to bring inline (or exceed) GEOSgcm v10.20.0
+
+  - ESMA_env v3.4.0 → v3.10.0
+  - ESMA_cmake v3.6.2 → v3.8.0
+  - GMAO_Shared v1.4.10 → v1.5.0
+  - FVdycoreCubed_GridComp v1.2.17 → v1.5.0
+  * fvdycore geos/v1.1.7 → geos/v1.3.0
+  - MAPL v2.8.6 → v2.14.1
+
+- Update CircleCI to use Intel 2021.3
+- Update `CODEOWNERS`
+
+### Fixed
+
+- Fixed CMake to be like GEOSgcm
+
+### Added
+
+- Added EditorConfig support.
+- Added changelog enforcer
+- Added `CHANGELOG.md`
+
+## [1.3.0] - 2021-10-08
+
+### Changed
+
+* This release moves the GEOSfvdycore repo to be in line with GEOSgcm v10.19.4. Updates include:
+
+  * ESMA_env v3.3.1 → v3.4.0
+  * ESMA_cmake v3.5.4 → v3.6.2
+  * GMAO_Shared v1.4.6 → v1.4.10
+  * FVdycoreCubed_GridComp v1.2.16 → v1.2.17
+  * MAPL v2.8.4 → v2.8.6
+
+## [1.2.10] - 2021-08-27
+
+### Changed
+
+* Update components to be in line with GEOSgcm (or newer):
+
+  * ESMA_env v3.3.0 → v3.3.1
+  * ESMA_cmake v3.5.2 → v3.5.4
+  * GMAO_Shared v1.4.5 → v1.4.6
+  * FVdycoreCubed_GridComp v1.2.15 → v1.2.16
+
+## [1.2.9] - 2021-07-19
+
+### Changed
+
+* Update components to be in line with GEOSgcm:
+
+  * ESMA_cmake v3.5.0 → v3.5.2
+  * GMAO_Shared v1.4.3 → v1.4.5
+  * fvdycore geos/v1.1.6 → geos/v1.1.7
+
+## [1.2.8] - 2021-07-07
+
+### Changed
+
+* Update components to be in line with GEOSgcm v10.19.2:
+
+  * ESMA_env v3.2.1 → v3.3.0
+  * ESMA_cmake v3.4.2 → v3.5.0
+  * GMAO_Shared v1.4.1 → v1.4.3
+
+## [1.2.7] - 2021-05-25
+
+### Changed
+
+* This updates GEOSfvdycore to be inline with GEOS v10.19.1. Updates include:
+
+  * ESMA_env v3.2.1
+  * ESMA_cmake v3.4.2
+  * GMAO_Shared v1.4.1
+  * MAPL v2.7.0
+  * FMS geos/2019.01.02+noaff.7
+  * FVdycoreCubed_GridComp v1.2.15
+
+
+## [1.2.6] - 2021-04-14
+
+### Changed
+* Update to `components.yaml` to match GEOSgcm `main` as of 2021-Apr-14:
+  * ESMA_env v6.2.0
+  * ESMA_cmake v3.3.9
+  * GMAO_Shared v1.3.10
+  * FVdycoreCubed_GridComp v1.2.12
+  * fvdycore geos/v1.1.6
+
+## [1.2.5] - 2021-04-02
+
+### Changed
+
+* Update to use MAPL 2.6.4, FVdycoreCubed_GridComp 1.2.11, and fvdycore v1.1.5
+
+## [1.2.4] - 2021-03-25
+
+### Changed
+
+* This release brings GEOSfvdycore's sub repos in line with GEOSgcm v10.17.4
+
+## [1.2.3] - 2021-03-09
+
+### Changed
+
+* Update `components.yaml` to match GEOSgcm v10.17.3
+
+## [1.2.2] - 2020-12-17
+
+### Changed
+
+* This PR advances many components to match GEOSgcm
+
+## [1.2.1] - 2020-12-02
+
+### Changed
+
+* Updates the `fv3.j` script to allow for GEOS shared object libraries.
+
+## [1.2.0] - 2020-11-30
+
+### Changed
+
+* This release updates the GEOSfvdycore fixture sub-repos to match GEOSgcm v10.17.0:
+
+  * Intel 19.1.3 (ESMA_cmake v3.1.1)
+  * MAPL 2.4.0
+
+  and more.
+
+
+## [1.1.2] - 2020-10-30
+
+### Changed
+
+* Add to `components.yaml` to allow `mepo` to see the fixture.
+
+## [1.1.1] - 2020-10-28
+
+### Changed
+
+* Update `components.yaml` to match GEOSgcm:
+
+  * ESMA_env v3.0.1
+  * GMAO_Shared v1.3.2
+  * MAPL v2.3.4
+
+## [1.1.0] - 2020-10-06
+
+### Changed
+
+* This version of GEOSfvdycore has equivalent subrepos to GEOSgcm 10.16.0.
+
+### Removed
+
+* Removes support on SLES 11
+
+## [1.0.6] - 2020-09-15
+
+### Changed
+
+* Update subcomponents:
+  * GMAO_Shared to v1.1.9
+  * FVdycoreCubed_GridComp to v1.2.5
+
+## [1.0.5] - 2020-09-10
+
+### Fixed
+
+* Fix `fv3.j` and `fv3_setup` to correctly handle IOSERVER.
+
+## [1.0.4] - 2020-08-20
+
+### Changed
+
+* Updates to CircleCI
+
+### Fixed
+
+* Fix to `fv3_setup`
+
+## [1.0.3] - 2020-08-20
+
+### Changed
+
+- Update `components.yaml` to:
+  - ESMA_cmake v3.1.3
+  - GMAO_Shared v1.1.8
+  - FMS geos/2019.01.02+noaff.1
+  - FVdycoreCubed_GridComp v1.2.2
+
+### Added
+
+- Add a CircleCI test for building fixture
+
+### Removed
+
+- Remove Github Actions build test
+
+## [1.0.2] - 2020-08-11
+
+### Changed
+
+* Move GEOSfvdycore to use [FVdycoreCubed_GridComp v1.2.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.1) which is a zero-diff update that affects the `fv3.j` script used to run the FV3 Standalone.
+
+## [1.0.1] - 2020-08-04
+
+### Changed
+
+* Updates to bring GEOSfvdycore in line with GEOSgcm
+
+## [1.0.0] - 2020-07-22
+
+### Added
+
+* This is the initial release of GEOSfvdycore which allows one to run the GEOS FV3 Standalone.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 1.3
+  VERSION 1.4.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -34,6 +34,7 @@ set (FV_PRECISION "R4" CACHE STRING "Precision of FV3 core (R4, R4R8, R8)")
 foreach (dir cmake @cmake cmake@)
   if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
     list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
+    set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
   endif ()
 endforeach ()
 include (esma)
@@ -63,5 +64,5 @@ install(
    DESTINATION ${CMAKE_INSTALL_PREFIX}
    )
 
-# Adds abiilty to tar source
+# Adds ability to tar source
 include (esma_cpack)

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.0
+  tag: v3.10.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.2
+  tag: v3.8.0
   develop: develop
 
 ecbuild:
@@ -22,14 +22,14 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10
+  tag: v1.5.0
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.8.6
+  tag: v2.14.1
   develop: develop
 
 FMS:
@@ -41,12 +41,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.17
+  tag: v1.5.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.1.7
+  tag: geos/v1.3.0
   develop: geos/develop
 


### PR DESCRIPTION
Many updates:

- Updates to `components.yaml` to bring inline (or exceed) GEOSgcm v10.20.0

  - ESMA_env v3.4.0 → v3.10.0
  - ESMA_cmake v3.6.2 → v3.8.0
  - GMAO_Shared v1.4.10 → v1.5.0
  - FVdycoreCubed_GridComp v1.2.17 → v1.5.0
  * fvdycore geos/v1.1.7 → geos/v1.3.0
  - MAPL v2.8.6 → v2.14.1

- Update CircleCI to use Intel 2021.3
- Update `CODEOWNERS`

### Fixed

- Fixed CMake to be like GEOSgcm

### Added

- Added EditorConfig support.
- Added changelog enforcer
- Added `CHANGELOG.md`