### PR TITLE
Update GEOSfvdycore to be same as GCM v10.22.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,7 @@
 version: 2.1
 
-executors:
-  gfortran-large:
-    docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_AUTH_TOKEN
-    environment:
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-    resource_class: large
-    #MEDIUM# resource_class: medium
-
-  ifort-large:
-    docker:
-      - image: gmao/ubuntu20-geos-env:v6.2.8-intelmpi_2021.3.0-intel_2021.3.0
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_AUTH_TOKEN
-    resource_class: large
-    #MEDIUM# resource_class: medium
+orbs:
+  circleci-tools: geos-esm/circleci-tools@0.13.0
 
 workflows:
   version: 2.1
@@ -65,43 +45,18 @@ jobs:
     steps:
       - checkout:
           path: GEOSfvdycore
-      - run:
-          name: "Versions etc"
-          command: mpirun --version && << parameters.compiler>> --version && echo $BASEDIR && pwd && ls
-      - run:
-          name: "Mepo clone external repos"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSfvdycore
-            mepo clone
-            mepo status
-      - run:
-          name: "Mepo checkout-if-exists"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSfvdycore
-            echo "${CIRCLE_BRANCH}"
-            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
-            then
-               mepo checkout-if-exists ${CIRCLE_BRANCH}
-            fi
-            mepo status
-      - run:
-          name: "CMake"
-          command: |
-            mkdir -p /logfiles
-            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSfvdycore
-            mkdir -p  ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSfvdycore
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSfvdycore
-            cmake ${CIRCLE_WORKING_DIRECTORY}/GEOSfvdycore -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=<< parameters.compiler >> -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${CIRCLE_WORKING_DIRECTORY}/workspace/install-GEOSfvdycore -DUSE_F2PY=OFF |& tee /logfiles/cmake.log
-      - run:
-          name: "Build and install"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSfvdycore
-            make -j"$(nproc)" install |& tee /logfiles/make.log
-            #MEDIUM# make -j4 install |& tee /logfiles/make.log
-      - run:
-          name: "Compress artifacts"
-          command: |
-            gzip -9 /logfiles/*
+      - circleci-tools/versions:
+          compiler: << parameters.compiler >>
+      - circleci-tools/mepoclone:
+          repo: GEOSfvdycore
+      - circleci-tools/checkout_if_exists:
+          repo: GEOSfvdycore
+      - circleci-tools/cmake:
+          compiler: << parameters.compiler >>
+          repo: GEOSfvdycore
+      - circleci-tools/buildinstall:
+          repo: GEOSfvdycore
+      - circleci-tools/compress_artifacts
       - store_artifacts:
           path: /logfiles
       # We need to persist the install for the next step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,9 @@ jobs:
     parameters:
       compiler:
         type: string
-    executor: << parameters.compiler >>-large
+    executor:
+      name: circleci-tools/<< parameters.compiler >>
+      resource_class: large
     working_directory: /root/project
     steps:
       - checkout:
@@ -72,7 +74,9 @@ jobs:
     parameters:
       compiler:
         type: string
-    executor: << parameters.compiler >>-large
+    executor:
+      name: circleci-tools/<< parameters.compiler >>
+      resource_class: large
     working_directory: /root/project
     steps:
       - attach_workspace:
@@ -118,7 +122,9 @@ jobs:
     parameters:
       compiler:
         type: string
-    executor: << parameters.compiler >>-large
+    executor:
+      name: circleci-tools/<< parameters.compiler >>
+      resource_class: large
     working_directory: /root/project
     steps:
       - attach_workspace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [1.5.0] - 2022-03-21
+
+- Updates to `components.yaml` to bring inline (or exceed) GEOSgcm v10.22.1
+
+  - ESMA_env v3.10.0 → v3.13.0
+  - ESMA_cmake v3.8.0 → v3.12.0
+  - GMAO_Shared v1.5.0 → v1.5.3
+  - FVdycoreCubed_GridComp v1.5.0 → v1.6.0
+  - MAPL v2.14.1 → v2.19.0
+
+- Update CircleCI to use orbs
+
 ## [1.4.0] - 2021-12-21
 
 ### Changed
@@ -27,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ESMA_cmake v3.6.2 → v3.8.0
   - GMAO_Shared v1.4.10 → v1.5.0
   - FVdycoreCubed_GridComp v1.2.17 → v1.5.0
-  * fvdycore geos/v1.1.7 → geos/v1.3.0
+  - fvdycore geos/v1.1.7 → geos/v1.3.0
   - MAPL v2.8.6 → v2.14.1
 
 - Update CircleCI to use Intel 2021.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2022-03-21
 
+### Changed
+
 - Updates to `components.yaml` to bring inline (or exceed) GEOSgcm v10.22.1
 
   - ESMA_env v3.10.0 → v3.13.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 1.4.0
+  VERSION 1.5.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -26,8 +26,8 @@ set (DOING_GEOS5 YES)
 # Should find a better place for this - used in Chem component
 set (ACG_FLAGS -v)
 
-# This flag at R4 means that FV3 is compiled at R4 and *linked* to 
-# FMS built at R4. 
+# This flag at R4 means that FV3 is compiled at R4 and *linked* to
+# FMS built at R4.
 set (FV_PRECISION "R4" CACHE STRING "Precision of FV3 core (R4, R4R8, R8)")
 
 # mepo can now clone subrepos in three styles

--- a/components.yaml
+++ b/components.yaml
@@ -5,43 +5,43 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.10.0
+  tag: v3.13.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.8.0
+  tag: v3.12.0
   develop: develop
 
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v1.0.6
+  tag: geos/v1.2.0
 
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.5.0
+  tag: v1.5.3
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.14.1
+  tag: v2.19.0
   develop: develop
 
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02+noaff.7
+  tag: geos/2019.01.02+noaff.8
   develop: geos/release/2019.01
 
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.5.0
+  tag: v1.6.0
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This brings GEOSfvdycore up to date with GEOSgcm v10.22.1:

- Updates to `components.yaml` to bring inline (or exceed) GEOSgcm v10.22.1

  - ESMA_env v3.10.0 → v3.13.0
  - ESMA_cmake v3.8.0 → v3.12.0
  - GMAO_Shared v1.5.0 → v1.5.3
  - FVdycoreCubed_GridComp v1.5.0 → v1.6.0
  - MAPL v2.14.1 → v2.19.0

- Update CircleCI to use orbs