### PR TITLE
Fix issue with FV_PRECISION and FMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [1.8.1] - 2022-08-22
+
+### Fixed
+
+- Fix handling of `FV_PRECISION` in CMake
+
 ## [1.8.0] - 2022-08-05
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 1.8.0
+  VERSION 1.8.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set (ACG_FLAGS -v)
 
 # This flag at R4 means that FV3 is compiled at R4 and *linked* to
 # FMS built at R4.
-set (FV_PRECISION "R4" CACHE STRING "Precision of FV3 core (R4, R4R8, R8)")
+set (FV_PRECISION "R4" CACHE STRING "Precision of FV3 core (R4, R8)")
 
 # mepo can now clone subrepos in three styles
 foreach (dir cmake @cmake cmake@)

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -3,4 +3,11 @@ esma_add_subdirectories (
   GMAO_Shared
   )
 
-esma_add_subdirectory (FMS RENAME fms_r4)
+if (FV_PRECISION STREQUAL R4)
+  esma_add_subdirectory (FMS RENAME fms_r4)
+elseif (FV_PRECISION STREQUAL R8)
+  esma_add_subdirectory (FMS RENAME fms_r8)
+elseif (FV_PRECISION STREQUAL R4R8)
+  esma_add_subdirectory (FMS RENAME fms_r4)
+  esma_add_subdirectory (FMS RENAME fms_r8)
+endif ()


### PR DESCRIPTION
Testing with single and double precision showed a bug in how FMS was handled with cmake. It would always use fms_r4 even at double precision.