### PR TITLE
Update to ESMA_env 4.3.0 (Intel 2022.1) and ESMA_cmake v3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [1.9.0] - 2022-08-25
+
+### Changed
+
+- Update to `components.yaml`
+
+  - ESMA_env v4.2.0 → v4.3.0 (Intel 2022.1)
+  - ESMA_cmake v3.17.0 → v3.18.0
+
 ## [1.8.1] - 2022-08-22
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 1.8.1
+  VERSION 1.9.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.2.0
+  tag: v4.3.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.17.0
+  tag: v3.18.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates the FV3 standalone to use Intel 2022.1 (aka Intel Fortran 2021.6).