### PR TITLE
Update components to match latest GEOSgcm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [1.11.0] - 2022-10-11
+
+### Changed
+
+- Update to `components.yaml`
+
+  - GMAO_Shared v1.5.7 → v1.6.1
+  - MAPL v2.23.1 → v2.27.1
+  - FVdycoreCubed_Gridcomp v1.11.0 → v1.12.1
+  - fvdycore geos/v1.4.0 → geos/v1.5.0
+
 ## [1.10.0] - 2022-09-01
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.17)
 cmake_policy (SET CMP0053 NEW)
 cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 1.10.0
+  VERSION 1.11.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -22,14 +22,14 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.5.7
+  tag: v1.6.1
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.23.1
+  tag: v2.27.1
   develop: develop
 
 FMS:
@@ -41,12 +41,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.11.0
+  tag: v1.12.1
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.4.0
+  tag: geos/v1.5.0
   develop: geos/develop
 


### PR DESCRIPTION
This PR updates the `components.yaml` to match that of GEOSgcm (or slightly exceed):

  - GMAO_Shared v1.5.7 → v1.6.1
  - MAPL v2.23.1 → v2.27.1
  - FVdycoreCubed_Gridcomp v1.11.0 → v1.12.1
  - fvdycore geos/v1.4.0 → geos/v1.5.0