### PR TITLE
Move to use GitHub Action for Label Enforcement

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -8,9 +8,22 @@ jobs:
   require-label:
     runs-on: ubuntu-latest
     steps:
-    - uses: yogevbd/enforce-label-action@2.2.2
-      with:
-        REQUIRED_LABELS_ANY: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled,dependencies"
-        BANNED_LABELS: "Contingent - DNA,Needs Lead Approval,Contingent -- Do Not Approve"
-        BANNED_LABELS_DESCRIPTION: "The label ${bannedLabel.name} is blocking this PR from being merged"
-
+      - uses: mheap/github-action-required-labels@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: minimum
+          count: 1
+          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled"
+          add_comment: true
+  blocking-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: exactly
+          count: 0
+          labels: "Contingent - DNA,Needs Lead Approval,Contingent -- Do Not Approve"
+          add_comment: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved to use GitHub Actions for label enforcement
+
 ### Removed
 
 ### Deprecated


### PR DESCRIPTION
Due to changes at Heroku, we need to transition to use a GitHub Action for label enforcement. The current label enforcer no longer works, so PRs will be "stuck" until this is fixed.