### PR TITLE
Update components to match GEOSgcm v11.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
 baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.23.0
+bcs_version: &bcs_version v11.00.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 
 orbs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update to `components.yaml`
+  - ESMA_env v4.8.0 → v4.9.1
+  - ESMA_cmake v3.24.0 → v3.27.0
+  - GMAO_Shared v1.7.0 → v1.8.0
+  - MAPL v2.34.1 → v2.35.2
+  - FVdycoreCubed_GridComp v1.12.1 → v2.0.0
+  - fvdycore geos/v1.5.0 → geos/v2.0.0
+
 ### Removed
 
 ### Deprecated

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.8.0
+  tag: v4.9.1
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.24.0
+  tag: v3.27.0
   develop: develop
 
 ecbuild:
@@ -22,14 +22,20 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.7.0
+  tag: v1.8.0
   sparse: ./config/GMAO_Shared.sparse
+  develop: main
+
+GEOS_Util:
+  local: ./src/Shared/@GMAO_Shared/@GEOS_Util
+  remote: ../GEOS_Util.git
+  tag: v1.1.0
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.34.1
+  tag: v2.35.2
   develop: develop
 
 FMS:
@@ -41,12 +47,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.12.1
+  tag: v2.0.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.5.0
+  tag: geos/v2.0.0
   develop: geos/develop
 

--- a/components.yaml
+++ b/components.yaml
@@ -47,7 +47,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.0.0
+  branch: bugfix/mathomp4/fix-standalone
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This PR is to update GEOSfvdycore to match GEOSgcm v11. I know it needs fixes in FV3 scripting.