### PR TITLE
Updates for v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to `components.yaml`
-  - ESMA_env v4.8.0 → v4.9.1
-  - ESMA_cmake v3.24.0 → v3.27.0
-  - GMAO_Shared v1.7.0 → v1.8.0
-  - MAPL v2.34.1 → v2.35.2
-  - FVdycoreCubed_GridComp v1.12.1 → v2.0.0
-  - fvdycore geos/v1.5.0 → geos/v2.0.0
-
 ### Removed
 
 ### Deprecated
+
+## [2.0.0] - 2023-03-23
+
+### Changed
+
+- Update to `components.yaml`
+  - ESMA_env v4.8.0 → v4.9.1
+  - ESMA_cmake v3.24.0 → v3.28.0
+  - GMAO_Shared v1.7.0 → v1.8.0
+  - MAPL v2.34.1 → v2.35.3
+  - FVdycoreCubed_GridComp v1.12.1 → v2.1.0
+  - fvdycore geos/v1.5.0 → geos/v2.1.0
+
+### Added
+
+- Added GEOS_Util v1.1.0 to `components.yaml`
 
 ## [1.14.0] - 2023-02-09
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 1.14.0
+  VERSION 2.0.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.27.0
+  tag: v3.28.0
   develop: develop
 
 ecbuild:
@@ -47,12 +47,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  branch: develop
+  tag: v2.1.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.0.0
+  tag: geos/v2.1.0
   develop: geos/develop
 


### PR DESCRIPTION
This PR updates FV3 standalone to use:

  - ESMA_env v4.8.0 → v4.9.1
  - ESMA_cmake v3.24.0 → v3.28.0
  - GMAO_Shared v1.7.0 → v1.8.0
  - MAPL v2.34.1 → v2.35.3
  - FVdycoreCubed_GridComp v1.12.1 → v2.1.0
  - fvdycore geos/v1.5.0 → geos/v2.1.0

which echoes GEOSgcm v11.0.0