### PR TITLE
Update components.yaml to match GEOSgcm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,26 +27,28 @@ workflows:
   build-test:
     jobs:
       - ci/build:
-          name: build-GEOSfvdycore-on-<< matrix.compiler >>
+          name: build-GEOSfvdycore-as-<< matrix.fv_precision >>-on-<< matrix.compiler >>
           context:
             - docker-hub-creds
           matrix:
             parameters:
               compiler: [ifort, gfortran]
+              fv_precision: ["R4", "R8"]
           baselibs_version: *baselibs_version
           repo: GEOSfvdycore
           mepodevelop: false
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
       - ci/run_fv3:
-          name: run-FV3-on-<< matrix.compiler >>
+          name: run-FV3-as-<< matrix.fv_precision >>-on-<< matrix.compiler >>-with-GEOSfvdycore
           context:
             - docker-hub-creds
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+              fv_precision: ["R4", "R8"]
           baselibs_version: *baselibs_version
           requires:
-            - build-GEOSfvdycore-on-<< matrix.compiler >>
+            - build-GEOSfvdycore-as-<< matrix.fv_precision >>-on-<< matrix.compiler >>
           repo: GEOSfvdycore
   build-and-publish-docker:
     when:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,15 @@ updates:
     directory: "/" # Dependabot knows to look in .github/workflows for GitHub Actions
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "github_actions"
 
   # Enable daily updates for Docker
   - package-ecosystem: "docker"
     directory: "/.docker" # Location of Dockerfile
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 parallel_build.o*
 log.*
 CMakeUserPresets.json
+
+*.swp
+*.swo
+.DS_Store
+*#
+.#*
+**/CVS/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - FVdycoreCubed_GridComp v2.2.2 → v2.3.0
   - fvdycore geos/v2.3.0 → geos/v2.4.0
   - GMAO_Shared v1.8.0 → v1.9.0
+- Update CI to test both R4 and R8 FV precision
 
 ## [2.2.0] - 2023-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.3.0] - 2023-05-10
+
+### Changed
+
+- Update to `components.yaml`
+  - MAPL v2.37.0 → v2.38.1
+  - FVdycoreCubed_GridComp v2.2.2 → v2.3.0
+  - fvdycore geos/v2.3.0 → geos/v2.4.0
+  - GMAO_Shared v1.8.0 → v1.9.0
+
 ## [2.2.0] - 2023-04-03
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.2.0
+  VERSION 2.3.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,8 +14,7 @@
       "binaryDir": "${sourceDir}/build-${presetName}",
       "cacheVariables": {
         "BASEDIR": "$env{BASEDIR}",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
-        "CMAKE_BUILD_TYPE": "${presetName}"
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
       }
     },
     {
@@ -38,37 +37,55 @@
       "name": "Release",
       "inherits": "base-gnu",
       "displayName": "Release Configure",
-      "description": "Release build using GNU Make generator"
+      "description": "Release build using GNU Make generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     },
     {
       "name": "Debug",
       "inherits": "base-gnu",
       "displayName": "Debug Configure",
-      "description": "Debug build using GNU Make generator"
+      "description": "Debug build using GNU Make generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
     },
     {
       "name": "Aggressive",
       "inherits": "base-gnu",
       "displayName": "Aggressive Configure",
-      "description": "Aggressive build using GNU Make generator"
+      "description": "Aggressive build using GNU Make generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Aggressive"
+      }
     },
     {
       "name": "Release-Ninja",
       "inherits": "base-ninja",
       "displayName": "Release Ninja Configure",
-      "description": "Release build using Ninja generator"
+      "description": "Release build using Ninja generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     },
     {
       "name": "Debug-Ninja",
       "inherits": "base-ninja",
       "displayName": "Debug Ninja Configure",
-      "description": "Debug build using Ninja generator"
+      "description": "Debug build using Ninja generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
     },
     {
       "name": "Aggressive-Ninja",
       "inherits": "base-ninja",
       "displayName": "Aggressive Ninja Configure",
-      "description": "Aggressive build using Ninja generator"
+      "description": "Aggressive build using Ninja generator",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Aggressive"
+      }
     }
   ],
   "buildPresets": [

--- a/components.yaml
+++ b/components.yaml
@@ -22,7 +22,7 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.8.0
+  tag: v1.9.0
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
@@ -35,7 +35,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.37.0
+  tag: v2.38.1
   develop: develop
 
 FMS:
@@ -47,12 +47,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.2.2
+  tag: v2.3.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.3.0
+  tag: geos/v2.4.0
   develop: geos/develop
 


### PR DESCRIPTION
This PR updates the `components.yaml` to match that of GEOSgcm `main` (soon to be v11).

This is non-zero-diff to older versions.