### PR TITLE
Update to Baselibs 7.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.7.0
+baselibs_version: &baselibs_version v7.13.0
 bcs_version: &bcs_version v11.00.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to `components.yaml`
-  - ESMA_env v4.9.3 → v4.17.0
-- Update CI to Baselibs 7.13.0
-
 ### Removed
 
 ### Deprecated
+
+## [2.5.0] - 2023-06-08
+
+- Update to `components.yaml`
+  - ESMA_env v4.9.3 → v4.17.0
+- Update CI to Baselibs 7.13.0
 
 ## [2.4.3] - 2023-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update to `components.yaml`
+  - ESMA_env v4.9.3 → v4.17.0
+- Update CI to Baselibs 7.13.0
+
 ### Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.5.0] - 2023-06-08
 
 - Update to `components.yaml`
-  - ESMA_env v4.9.3 → v4.17.0
+  - ESMA_env v4.9.3 → v4.17.0 (Baselibs 7.13.0)
+  - GMAO_Shared v1.9.0 → v1.9.1 (match GEOSgcm)
 - Update CI to Baselibs 7.13.0
 
 ## [2.4.3] - 2023-06-08

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.4.3
+  VERSION 2.5.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -22,7 +22,7 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.9.0
+  tag: v1.9.1
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.9.3
+  tag: v4.17.0
   develop: main
 
 cmake:


### PR DESCRIPTION
With GEOSgcm moving to Baselibs 7.13.0 in v11.1.0, we now move GEOSfvdycore to the same.