### PR TITLE
Update to FVdycoreCubed_GridComp v2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.4.2] - 2023-06-05
+
+### Changed
+
+- Update FVdycoreCubed_GridComp v2.4.2 → v2.4.3
+  - Adds a new `--site` flag to `fv3_setup` for use with containers
+
 ## [2.4.1] - 2023-06-02
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.4.0
+  VERSION 2.4.2
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -47,7 +47,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.4.2
+  tag: v2.4.3
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This PR adds updates to FVdycoreCubed_GridComp v2.4.3 which adds a `--site` option to `fv3_setup`. This is needed because it was found that images built in, say, GitHub Container Registry were being detected as an AWS build (which might be true). But we'd want to run at NCCS. So now you can do:
```
./fv3_setup --site NCCS
```