### PR TITLE
Update to FVdycoreCubed_GridComp v2.4.4, fvdycore geos/v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.4.3] - 2023-06-08
+
+### Fixed
+
+- Update fvdycore geos/v2.4.0 → geos/v2.4.1
+  - Fixes bug with adiabatic/FV3 Standalone runs
+- Update FVdycoreCubed_GridComp v2.4.3 → v2.4.4
+  - Removes `FV3_CONFIG: MONOTONIC` from `fv3.j` as that is not needed with the fix from fvdycore geos/v2.4.1
+
 ## [2.4.2] - 2023-06-05
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.4.2
+  VERSION 2.4.3
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -47,12 +47,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.4.3
+  tag: v2.4.4
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.4.0
+  tag: geos/v2.4.1
   develop: geos/develop
 


### PR DESCRIPTION
This PR updates to [FVdycoreCubed_GridComp v2.4.4](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.4) and [fvdycore geos/v2.4.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.4.1)

This has fixes for the FV3 Standalone that let it actually work and not do 0K steady-state.