### PR TITLE
Update to FV3 GC 2.5.0, MAPL 2.39.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.6.0] - 2023-06-16
+
+### Changed
+
+- Update to `components.yaml`
+  - FVdycoreCubed_GridComp v2.4.4 → v2.5.0
+    - Changes to make singularity runs simpler
+    - Clean up use of global memory in interp_restarts.x
+    - Separate init and finalize in geos-gtfv3
+  - MAPL v2.39.1 → v2.39.3
+    - Minor fixes
+
 ## [2.5.0] - 2023-06-08
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.5.0
+  VERSION 2.6.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -35,7 +35,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.39.1
+  tag: v2.39.3
   develop: develop
 
 FMS:
@@ -47,7 +47,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.4.4
+  tag: v2.5.0
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This PR updates FVdycoreCubed_GridComp and MAPL. The FV3 GC updates that matter most to GEOSfvdycore are changes to scripting by @AnikMumssen21 to make Singularity use much easier.

This is zero diff to v2.5.0