### PR TITLE
Update components to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.13.0
-bcs_version: &bcs_version v11.00.0
+baselibs_version: &baselibs_version v7.14.0
+bcs_version: &bcs_version v11.1.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 
 orbs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.7.0] - 2023-08-10
+
+### Changed
+
+- Update to `components.yaml` (matches or exceeds GEOSgcm v11.1.1)
+  - ESMA_env v4.17.0 → v4.19.0
+    - Update to Baselibs 7.14.0
+      - ESMF 8.5.0
+      - GFE v1.11.0
+  - ESMA_cmake v3.29.0 → v3.31.1
+    - Add `QUIET_DEBUG` option
+    - Suppress some common Intel warnings
+    - Fixes for NAG
+  - GEOS_Util v2.0.0 → v2.0.2
+    - Plot updates
+    - Fixes for remapping catchment restarts
+  - MAPL v2.39.3 → v2.40.3
+    - Update to use ESMF Hconfig (which means ESMF 8.5.0 is *required*; this is from ESMA_env v4.19.0)
+    - Update required GFE library versions
+      - gFTL 1.10.0
+      - gFTL-shared 1.6.1
+      - fArgParse 1.5.0 (if -DBUILD_WITH_FARGPARSE=YES, default=YES)
+      - pFlogger 1.9.5 (if -DBUILD_WITH_PFLOGGER=YES, default=YES)
+    - `ExtDataDriver.x` can now handle tile grids
+    - Various bug fixes for NAG
+  - FVdycoreCubed_GridComp v2.5.0 → v2.6.0
+    - More cleanup for Singularity use
+- Update CircleCI
+
 ## [2.6.0] - 2023-06-16
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.6.0
+  VERSION 2.7.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.17.0
+  tag: v4.19.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.29.0
+  tag: v3.31.1
   develop: develop
 
 ecbuild:
@@ -29,13 +29,13 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.0.0
+  tag: v2.0.2
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.39.3
+  tag: v2.40.3
   develop: develop
 
 FMS:
@@ -47,7 +47,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.5.0
+  tag: v2.6.0
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This PR updates the components for GEOSfvdycore to match or exceed those in GEOSgcm v11.1.1

Also has updates to `fv3_setup` and `fv3.j` from @AnikMumssen21 to make Singularity use cleaner and easier