### PR TITLE
Update to fvdycore geos/v2.7.0, and other components to match GEOSgcm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.10.0] - 2023-11-09
+
+- Update to `components.yaml` to match (or exceed) GEOSgcm `main` as of 2023-11-09
+  - ESMA_env v4.20.4 → v4.20.6
+    - More fixes for build.csh
+  - ESMA_cmake v3.35.0 → v3.36.0
+    - Fixes for Intel icx and on macOS Rosetta
+  - GMAO_Shared v1.9.5 → v1.9.6
+    - Fixes for regrid.pl on SLES15
+  - MAPL v2.41.1 → v2.42.0
+    - Various workarounds for building MAPL with MPICH
+    - Added a new benchmark to simulate writing a cubed-sphere file using various tunable strategies
+    - Introduced workaround for Intel 2021.10 bug in generic layer.
+    - Updated write_by_oserver logic so that the decision to write by the oserver is based on whether the output server client is passed in
+    - Fixed incorrect History print during runtime
+  - fvdycore geos/v2.6.0 → geos/v2.7.0
+    - Add new algorithm for computing coordinates (disabled by default)
+
 ## [2.9.0] - 2023-10-25
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.8.0
+  VERSION 2.10.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.20.4
+  tag: v4.20.6
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.35.0
+  tag: v3.36.0
   develop: develop
 
 ecbuild:
@@ -22,7 +22,7 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.9.5
+  tag: v1.9.6
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
@@ -35,7 +35,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.41.1
+  tag: v2.42.0
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -53,6 +53,6 @@ FVdycoreCubed_GridComp:
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.6.0
+  tag: geos/v2.7.0
   develop: geos/develop
 


### PR DESCRIPTION
We need to update to fvdycore geos/v2.7.0 for the next FV3 GC release. This also updates other components.