### PR TITLE
Update to FVdycoreCubed_GridComp v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Fixed incorrect History print during runtime
   - fvdycore geos/v2.6.0 → geos/v2.7.0
     - Add new algorithm for computing coordinates (disabled by default)
+  - FVdycoreCubed_GridComp v2.8.0 → v2.9.0
+    - Add namelist entry for new algorithm for computing coordinates (disabled by default)
 
 ## [2.9.0] - 2023-10-25
 

--- a/components.yaml
+++ b/components.yaml
@@ -47,7 +47,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.8.0
+  tag: v2.9.0
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
Update to FVdycoreCubed_GridComp v2.9.0. Note that this *REQUIRES* [GFDL_atmos_cubed_sphere geos/v2.7.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.7.0)

