### PR TITLE
Update components to match GEOSgcm main as of 2023-Dec-19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.12.0] - 2023-12-19
+
+### Changed
+
+- Update to `components.yaml` to match GEOSgcm `main` as of 2023-12-19
+  - ESMA_env v4.22.0 → v4.24.0
+    - Update to Baselibs 7.17.0
+  - GEOS_Util v2.0.4 → v2.0.5
+    - Fix in remap_restarts.py for regridding from MERRA2 at non-72 level resolutions
+  - MAPL v2.42.0 → v2.42.4
+    - Various minor fixes found by NAG compiler
+  - fvdycore geos/v2.8.0 → geos/v2.8.1
+    - Fix when running with stretched grid
+
 ## [2.11.0] - 2023-12-01
 
 ### Changed

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.22.0
+  tag: v4.24.0
   develop: main
 
 cmake:
@@ -29,13 +29,13 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.0.4
+  tag: v2.0.5
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.42.0
+  tag: v2.42.4
   develop: develop
 
 FMS:
@@ -53,6 +53,6 @@ FVdycoreCubed_GridComp:
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.8.0
+  tag: geos/v2.8.1
   develop: geos/develop
 


### PR DESCRIPTION
Update to `components.yaml` to match GEOSgcm `main` as of 2023-12-19
  - ESMA_env v4.22.0 → v4.24.0
    - Update to Baselibs 7.17.0
  - GEOS_Util v2.0.4 → v2.0.5
    - Fix in remap_restarts.py for regridding from MERRA2 at non-72 level resolutions
  - MAPL v2.42.0 → v2.42.4
    - Various minor fixes found by NAG compiler
  - fvdycore geos/v2.8.0 → geos/v2.8.1
    - Fix when running with stretched grid
