### PR TITLE
Update components to match GEOSgcm main as of 2024-Feb-21

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -30,3 +30,4 @@ jobs:
           labels: "Contingent - DNA,Needs Lead Approval,Contingent -- Do Not Approve"
           add_comment: true
           message: "This PR is being prevented from merging because you have added one of our blocking labels: {{ provided }}. You'll need to remove it before this PR can be merged."
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.14.0] - 2024-02-21
+
+### Changed
+
+- Update to `components.yaml` to match GEOSgcm `main` as of 2024-02-21
+  - ESMA_cmake v3.38.0 → v3.41.0
+    - Use `ESMF::ESMF` as the target for ESMF
+    - Update `FindESMF.cmake`
+    - Add `DetermineMPIStack.cmake` to detect MPI stack at CMake time
+  - MAPL v2.43.0 → v2.44.0
+    - Various improvements to History "Samplers" that sample model data at geolocations of simulated instruments. These include support for both trajectories (time dependent lat/lon) and swaths (time-dependent scans)
+    - Added memory utility, MAPL_MemReport that can be used in any code linking MAPL
+    - Added capability in the MAPL ESMF regridding wrapper to apply a destination mask if the destination grid contains a mask
+    - Updates for using MAPL with GEOS in a hybrid MPI+OpenMP paradigm
+    - Various fixes for NVHPC work
+    - This version of MAPL now **_requires_** ESMF 8.6.0 as MAPL now uses functionality only supported in that version. Moreover, all references to ESMF as a CMake target are now done as `ESMF::ESMF`. This is supported in Baselibs build with ESMA_cmake v3.40.0 (**_required_** for Baselibs builds) and for non-Baselibs builds (i.e., spack) via a newer `FindESMF.cmake` file (currently from ESMF `develop` and will be in ESMF 8.6.1+).
+  = GMAO_Shared v1.9.6 → v1.9.7
+    - Updates for WMMA
+  - FVdycoreCubed_GridComp v2.10.0 → v2.11.0
+    - Updates to `fv3_setup` to use CMake detection of MPI stack (requires ESMA_cmake v3.41.0)
+
 ## [2.13.0] - 2024-01-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Updates for WMMA
   - FVdycoreCubed_GridComp v2.10.0 → v2.11.0
     - Updates to `fv3_setup` to use CMake detection of MPI stack (requires ESMA_cmake v3.41.0)
+- Pulled over other CMake changes from GEOSgcm (mainly developer related)
 
 ## [2.13.0] - 2024-01-26
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.13.0
+  VERSION 2.14.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,68 @@ foreach (dir cmake @cmake cmake@)
 endforeach ()
 include (esma)
 
+# Add CMake for when not using Baselibs
+if (NOT Baselibs_FOUND)
+  set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+  find_package(MPI)
+
+  find_package(NetCDF REQUIRED C Fortran)
+  add_definitions(-DHAS_NETCDF4)
+  add_definitions(-DHAS_NETCDF3)
+  add_definitions(-DNETCDF_NEED_NF_MPIIO)
+  add_definitions(-DHAS_NETCDF3)
+
+  find_package(HDF5 REQUIRED)
+  if(HDF5_IS_PARALLEL)
+     add_definitions(-DH5_HAVE_PARALLEL)
+  endif()
+
+  if (NOT TARGET esmf)
+    if (DEFINED ENV{esmf_ROOT})
+      message (STATUS "Found esmf_ROOT in environment: $ENV{esmf_ROOT}")
+      find_path(ESMF_CMAKE_PATH FindESMF.cmake HINTS "$ENV{esmf_ROOT}/cmake")
+      message (STATUS "Found FindESMF.cmake in: ${ESMF_CMAKE_PATH}")
+      if (ESMF_CMAKE_PATH)
+        message (STATUS "Appending to CMAKE_PREFIX_PATH: ${ESMF_CMAKE_PATH}")
+        list (APPEND CMAKE_MODULE_PATH ${ESMF_CMAKE_PATH})
+      endif ()
+    endif ()
+
+    find_package(ESMF MODULE REQUIRED)
+
+    # ESMF as used in MAPL requires MPI
+    # NOTE: This looks odd because some versions of FindESMF.cmake out in the
+    #       world provide an "esmf" target while others provide "ESMF". So we
+    #       need this ugliness to support both.
+    if (TARGET esmf)
+      target_link_libraries(esmf INTERFACE MPI::MPI_Fortran)
+    else()
+      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
+      # MAPL and GEOS use lowercase target due to historical reasons but
+      # the latest FindESMF.cmake file from ESMF produces an ESMF target.
+      add_library(esmf ALIAS ESMF)
+    endif()
+  endif ()
+
+  find_package(GFTL_SHARED REQUIRED)
+
+  find_package(ZLIB REQUIRED)
+  # Another issue with historical reasons, old/wrong zlib target used in GEOS
+  add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
+
+  # Using FMS from spack requires updates to fvdycore due to interface changes
+  # in FMS 2022. This is commented for now until this transition can occur.
+  #################################################
+  # find_package(FMS QUIET COMPONENTS R4 R8)      #
+  # if (FMS_FOUND)                                #
+  #   # We need aliases due to historical reasons #
+  #   add_library(fms_r4 ALIAS FMS::fms_r4)       #
+  #   add_library(fms_r8 ALIAS FMS::fms_r8)       #
+  # endif ()                                      #
+  #################################################
+
+endif ()
+
 ecbuild_declare_project()
 
 # Generic DFLAGS

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,22 +1,14 @@
 ﻿{
-  "version": 3,
+  "version": 7,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21,
+    "minor": 27,
     "patch": 0
   },
+  "include": [
+    "presets/CMake$penv{CMAKE_PRESET_NAME}Presets.json"
+  ],
   "configurePresets": [
-    {
-      "name": "base-configure",
-      "hidden": true,
-      "displayName": "Base Configure Settings",
-      "description": "Sets build and install directories",
-      "binaryDir": "${sourceDir}/build-${presetName}",
-      "cacheVariables": {
-        "BASEDIR": "$env{BASEDIR}",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
-      }
-    },
     {
       "name": "base-gnu",
       "hidden": true,

--- a/components.yaml
+++ b/components.yaml
@@ -47,7 +47,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.10.0
+  tag: v2.11.0
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.38.0
+  tag: v3.41.0
   develop: develop
 
 ecbuild:
@@ -22,7 +22,7 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.9.6
+  tag: v1.9.7
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
@@ -35,7 +35,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.43.0
+  tag: v2.44.0
   develop: develop
 
 FMS:

--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -32,8 +32,8 @@ end
 
 if (-d ${ESMADIR}/@env || -d ${ESMADIR}/env@ || -d ${ESMADIR}/env) then
    if ( "$DEVELOP" == "TRUE" ) then
-      echo "Checking out development branch of GMAO_Shared"
-      mepo develop GMAO_Shared
+      echo "Checking out development branch of GMAO_Shared and GEOS_Util"
+      mepo develop GMAO_Shared GEOS_Util
    endif
 else
    if ($?PBS_JOBID || $?SLURM_JOBID) then
@@ -46,8 +46,8 @@ else
       mepo init
       mepo clone
       if ( "$DEVELOP" == "TRUE" ) then
-         echo "Checking out development branch of GMAO_Shared"
-         mepo develop GMAO_Shared
+         echo "Checking out development branch of GMAO_Shared and GEOS_Util"
+         mepo develop GMAO_Shared GEOS_Util
    endif
    endif
 endif

--- a/presets/CMakeDefaultPresets.json
+++ b/presets/CMakeDefaultPresets.json
@@ -1,0 +1,13 @@
+﻿{
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "installDir": "${sourceDir}/install-${presetName}"
+    }
+  ],
+  "version": 7
+}

--- a/presets/CMakeNCCSPresets.json
+++ b/presets/CMakeNCCSPresets.json
@@ -1,0 +1,13 @@
+﻿{
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "$penv{CMAKE_BUILD_LOCATION}/${sourceDirName}/build-${presetName}",
+      "installDir": "$penv{CMAKE_INSTALL_LOCATION}/${sourceDirName}/install-${presetName}"
+    }
+  ],
+  "version": 7
+}


### PR DESCRIPTION
Keeping draft until FVdycoreCubed_GridComp v2.11.0 can be released. See https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/270

---

This PR updates GEOSfvdycore to use the components from GEOSgcm as of 2024-Feb-21

  - ESMA_cmake v3.38.0 → v3.41.0
    - Use `ESMF::ESMF` as the target for ESMF
    - Update `FindESMF.cmake`
    - Add `DetermineMPIStack.cmake` to detect MPI stack at CMake time
  - MAPL v2.43.0 → v2.44.0
    - Various improvements to History "Samplers" that sample model data at geolocations of simulated instruments. These include support for both trajectories (time dependent lat/lon) and swaths (time-dependent scans)
    - Added memory utility, MAPL_MemReport that can be used in any code linking MAPL
    - Added capability in the MAPL ESMF regridding wrapper to apply a destination mask if the destination grid contains a mask
    - Updates for using MAPL with GEOS in a hybrid MPI+OpenMP paradigm
    - Various fixes for NVHPC work
    - This version of MAPL now **_requires_** ESMF 8.6.0 as MAPL now uses functionality only supported in that version. Moreover, all references to ESMF as a CMake target are now done as `ESMF::ESMF`. This is supported in Baselibs build with ESMA_cmake v3.40.0 (**_required_** for Baselibs builds) and for non-Baselibs builds (i.e., spack) via a newer `FindESMF.cmake` file (currently from ESMF `develop` and will be in ESMF 8.6.1+).
  = GMAO_Shared v1.9.6 → v1.9.7
    - Updates for WMMA
  - FVdycoreCubed_GridComp v2.10.0 → v2.11.0
    - Updates to `fv3_setup` to use CMake detection of MPI stack (requires ESMA_cmake v3.41.0)