### PR TITLE
Update to components.yaml to match or exceed GEOSgcm as of 2024-Apr-29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.17.0
+baselibs_version: &baselibs_version v7.24.0
 bcs_version: &bcs_version v11.3.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 
@@ -90,9 +90,9 @@ workflows:
           baselibs_version: *baselibs_version
           container_name: geosfvdycore
           mpi_name: openmpi
-          mpi_version: 5.0.0
+          mpi_version: 5.0.2
           compiler_name: gcc
-          compiler_version: 12.1.0
+          compiler_version: 13.2.0
           image_name: geos-env-mkl
           tag_build_arg_name: *tag_build_arg_name
           resource_class: xlarge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.15.0] - 2024-04-30
+
+### Changed
+
+- Update to `components.yaml` to match or exceed GEOSgcm `main` as of 2024-04-29
+  - ESMA_env v4.25.1 → v4.29.0
+    - Update to Baselibs 7.24.0
+  - ESMA_cmake v3.41.0 → v3.45.0
+    - Add quiet flag to NAG
+    - Limit tests to ESSENTIAL
+    - Set BUILT_ON_SLES15 to FALSE if not
+    - Change to FindESMF.cmake and other updates
+  - GEOS_Util v2.0.5 → v2.0.8
+    - Various plots and remap updates
+  - MAPL v2.44.0 → v2.45.0
+    - Many, many, many changes (see https://github.com/GEOS-ESM/MAPL/compare/v2.44.0...v2.45.0)
+  - FVdycoreCubed_GridComp v2.11.0 → v2.11.1
+    - Fix variable use before set
+  - fvdycore geos/v2.8.1 → geos/v2.8.2
+    - Fix uninitialized variables
+
 ## [2.14.0] - 2024-02-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [2.15.0] - 2024-04-30
+## [2.15.0] - 2024-05-03
 
 ### Changed
 
@@ -31,8 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Change to FindESMF.cmake and other updates
   - GEOS_Util v2.0.5 → v2.0.8
     - Various plots and remap updates
-  - MAPL v2.44.0 → v2.45.0
+  - MAPL v2.44.0 → v2.46.0
     - Many, many, many changes (see https://github.com/GEOS-ESM/MAPL/compare/v2.44.0...v2.45.0)
+    - Support for spack build
   - FVdycoreCubed_GridComp v2.11.0 → v2.11.1
     - Fix variable use before set
   - fvdycore geos/v2.8.1 → geos/v2.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to `components.yaml` to match or exceed GEOSgcm `main` as of 2024-04-29
   - ESMA_env v4.25.1 → v4.29.0
     - Update to Baselibs 7.24.0
-  - ESMA_cmake v3.41.0 → v3.45.0
+  - ESMA_cmake v3.41.0 → v3.45.1
     - Add quiet flag to NAG
     - Limit tests to ESSENTIAL
     - Set BUILT_ON_SLES15 to FALSE if not

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.14.0
+  VERSION 2.15.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -37,12 +37,16 @@ foreach (dir cmake @cmake cmake@)
     set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
   endif ()
 endforeach ()
+
+# We need to find MPI before we go into esma
+# for the MPI stack detection to work
+set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+find_package(MPI)
+
 include (esma)
 
 # Add CMake for when not using Baselibs
 if (NOT Baselibs_FOUND)
-  set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
-  find_package(MPI)
 
   find_package(NetCDF REQUIRED C Fortran)
   add_definitions(-DHAS_NETCDF4)
@@ -55,31 +59,18 @@ if (NOT Baselibs_FOUND)
      add_definitions(-DH5_HAVE_PARALLEL)
   endif()
 
-  if (NOT TARGET esmf)
-    if (DEFINED ENV{esmf_ROOT})
-      message (STATUS "Found esmf_ROOT in environment: $ENV{esmf_ROOT}")
-      find_path(ESMF_CMAKE_PATH FindESMF.cmake HINTS "$ENV{esmf_ROOT}/cmake")
-      message (STATUS "Found FindESMF.cmake in: ${ESMF_CMAKE_PATH}")
-      if (ESMF_CMAKE_PATH)
-        message (STATUS "Appending to CMAKE_PREFIX_PATH: ${ESMF_CMAKE_PATH}")
-        list (APPEND CMAKE_MODULE_PATH ${ESMF_CMAKE_PATH})
-      endif ()
+  if (NOT TARGET ESMF::ESMF)
+    find_package(ESMF 8.6.1 MODULE REQUIRED)
+    target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
+
+    # GEOS uses lowercase target due to historical reasons but
+    # the latest FindESMF.cmake file from ESMF produces an ESMF::ESMF target.
+    if (NOT TARGET esmf)
+      add_library(esmf ALIAS ESMF::ESMF)
     endif ()
-
-    find_package(ESMF MODULE REQUIRED)
-
-    # ESMF as used in MAPL requires MPI
-    # NOTE: This looks odd because some versions of FindESMF.cmake out in the
-    #       world provide an "esmf" target while others provide "ESMF". So we
-    #       need this ugliness to support both.
-    if (TARGET esmf)
-      target_link_libraries(esmf INTERFACE MPI::MPI_Fortran)
-    else()
-      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
-      # MAPL and GEOS use lowercase target due to historical reasons but
-      # the latest FindESMF.cmake file from ESMF produces an ESMF target.
-      add_library(esmf ALIAS ESMF)
-    endif()
+    if (NOT TARGET ESMF)
+      add_library(ESMF ALIAS ESMF::ESMF)
+    endif ()
   endif ()
 
   find_package(GFTL_SHARED REQUIRED)

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.45.0
+  tag: v3.45.1
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -35,7 +35,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.45.0
+  tag: v2.46.0
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.25.1
+  tag: v4.29.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.41.0
+  tag: v3.45.0
   develop: develop
 
 ecbuild:
@@ -29,13 +29,13 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.0.5
+  tag: v2.0.8
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.44.0
+  tag: v2.45.0
   develop: develop
 
 FMS:
@@ -47,12 +47,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.11.0
+  tag: v2.11.1
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.8.1
+  tag: geos/v2.8.2
   develop: geos/develop
 


### PR DESCRIPTION
This PR updates GEOSfvdycore to match that in https://github.com/GEOS-ESM/GEOSgcm/pull/777

Tests on macOS shows this runs.