### PR TITLE
Update components to match GEOSgcm main as of 2025-Jan-28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v7.27.0
+baselibs_version: &baselibs_version v7.29.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.21.0] - 2025-01-28
+
+### Changed
+
+- Update to `components.yaml` to match or exceed GEOSgcm `main` as of 2025-01-28
+  - ESMA_env v4.34.0 → v4.34.1
+  - GEOS_Util v2.1.3 → v2.1.6
+  - MAPL v2.51.2 → v2.52.0
+- Various minor fixes to CMake and CircleCI
+
 ## [2.20.0] - 2025-01-16
 
 ### Changed
 
-- Update to `components.yaml` as of 2025-01-16
+- Update to `components.yaml` to match or exceed GEOSgcm `main` as of 2025-01-16
   - ESMA_env v4.29.1 → v4.34.0
   - ESMA_cmake v3.55.0 → v3.56.0
   - MAPL v2.51.1 → v2.51.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.20.0
+  VERSION 2.21.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -79,7 +79,7 @@ if (NOT Baselibs_FOUND)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
-  find_package(MAPL 2.51 QUIET)
+  find_package(MAPL 2.52 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.34.0
+  tag: v4.34.1
   develop: main
 
 cmake:
@@ -29,7 +29,7 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.1.3
+  tag: v2.1.6
   develop: main
 
 # When updating the MAPL version, also update the MAPL version in the
@@ -37,7 +37,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.51.2
+  tag: v2.52.0
   develop: develop
 
 FMS:

--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -35,6 +35,7 @@ if (-d ${ESMADIR}/@env || -d ${ESMADIR}/env@ || -d ${ESMADIR}/env) then
       echo "Checking out development branches of GMAO_Shared and GEOS_Util"
       mepo develop GMAO_Shared GEOS_Util
    endif
+   mepo status
 else
    if ($?PBS_JOBID || $?SLURM_JOBID) then
       echo " mepo clone must be run!"
@@ -42,13 +43,13 @@ else
       echo " Please run from a head node"
       exit 1
    else
-      echo "Running mepo initialization"
-      mepo init
+      echo "Running mepo clone"
       mepo clone
       if ( "$DEVELOP" == "TRUE" ) then
-         echo "Checking out development branch of GMAO_Shared and GEOS_Util"
+         echo "Checking out development branches of GMAO_Shared and GEOS_Util"
          mepo develop GMAO_Shared GEOS_Util
-   endif
+      endif
+      mepo status
    endif
 endif
 


### PR DESCRIPTION
- Update to `components.yaml` to match or exceed GEOSgcm `main` as of 2025-01-28
  - ESMA_env v4.34.0 → v4.34.1
  - GEOS_Util v2.1.3 → v2.1.6
  - MAPL v2.51.2 → v2.52.0
- Various minor fixes to CMake and CircleCI