### PR TITLE
v2: Update components to match GEOSgcm main as of 2026-01-14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v8.19.0
+baselibs_version: &baselibs_version v8.24.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 
@@ -94,9 +94,9 @@ workflows:
           #baselibs_version: *baselibs_version
           #container_name: geosfvdycore
           #mpi_name: intelmpi
-          #mpi_version: "2021.14"
+          #mpi_version: "2021.17"
           #compiler_name: ifx
-          #compiler_version: "2025.0"
+          #compiler_version: "2025.3"
           #image_name: geos-env
           #tag_build_arg_name: *tag_build_arg_name
           #resource_class: xlarge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.28.0] - 2026-01-14
+
+### Changed
+
+- Updated CI to use reusable workflows
+- Update to `components.yaml` to match or exceed GEOSgcm `main` as of 2026-01-14
+  - ESMA_env v5.14.0 → v5.17.0
+  - ESMA_cmake v3.65.0 → v3.69.0
+  - GMAO_Shared v2.1.4 → v2.1.6
+  - GEOS_Util v2.1.11 → v2.1.12
+  - MAPL v2.61.0 → v2.64.1
+  - FVdycoreCubed_GridComp v2.15.0 → v2.16.0
+  - fvdycore geos/v2.9.1 → geos/v2.10.0
+
 ## [2.27.0] - 2025-09-26
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.27.0
+  VERSION 2.28.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -79,7 +79,7 @@ if (NOT Baselibs_FOUND)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
-  find_package(MAPL 2.61 QUIET)
+  find_package(MAPL 2.64 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.14.0
+  tag: v5.17.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.65.0
+  tag: v3.69.0
   develop: develop
 
 ecbuild:
@@ -22,14 +22,14 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v2.1.4
+  tag: v2.1.6
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.1.11
+  tag: v2.1.12
   develop: main
 
 GMAO_perllib:
@@ -43,7 +43,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.61.0
+  tag: v2.64.1
   develop: develop
 
 FMS:
@@ -55,12 +55,12 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.15.0
+  tag: v2.16.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.9.1
+  tag: geos/v2.10.0
   develop: geos/develop
 


### PR DESCRIPTION
This updates `main` to match or exceed GEOSgcm as of 2026-01-14