### PR TITLE
v3: Update components to match GEOSgcm v12 as of 2026-01-14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v8.20.0
+baselibs_version: &baselibs_version v8.24.0
 bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 
@@ -94,9 +94,9 @@ workflows:
           #baselibs_version: *baselibs_version
           #container_name: geosfvdycore
           #mpi_name: intelmpi
-          #mpi_version: "2021.16"
+          #mpi_version: "2021.17"
           #compiler_name: ifx
-          #compiler_version: "2025.2"
+          #compiler_version: "2025.3"
           #image_name: geos-env
           #tag_build_arg_name: *tag_build_arg_name
           #resource_class: xlarge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if (NOT Baselibs_FOUND)
     endif ()
   endif ()
 
-  find_package(MAPL 2.62 QUIET)
+  find_package(MAPL 2.64 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/components.yaml
+++ b/components.yaml
@@ -5,31 +5,31 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.15.0
+  tag: v5.17.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.28.0
+  tag: v4.30.0
   develop: develop
 
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v2.1.0
+  tag: geos/v3.11.0
 
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: GCMv12-rc20
+  tag: GCMv12-rc21
   sparse: ./config/GMAO_Shared.sparse
   develop: feature/sdrabenh/gcm_v12
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: GCMv12-rc20
+  tag: GCMv12-rc21
   develop: feature/sdrabenh/gcm_v12
 
 GMAO_perllib:
@@ -43,17 +43,17 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.62.1
+  tag: v2.64.1
   develop: feature/sdrabenh/gcm_v12
 
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: GCMv12-rc20
+  tag: GCMv12-rc21
   develop: feature/sdrabenh/gcm_v12
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: GCMv12-rc20
+  tag: GCMv12-rc21
   develop: feature/sdrabenh/gcm_v12


### PR DESCRIPTION
This is updating the components based on `feature/sdrabenh/gcm_v12` in GEOSgcm as of 2026-01-14