### PR TITLE
v2: Update FV3 GC and other repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [2.30.0] - 2026-03-12
+## [2.30.0] - 2026-04-01
 
 ### Changed
 
-- Update `components.yaml` with bugfix for FV3 Standalone
-  - FVdycoreCubed_GridComp v2.15.0 → v2.16.0
+- Update `components.yaml` with bugfix for FV3 Standalone and to match or exceed GEOSgcm `main` as of 2026-04-01A
+  - ESMA_env v5.17.0 → v5.21.0
+  - ESMA_cmake v3.73.0 → v3.75.0
+  - FVdycoreCubed_GridComp v2.15.0 → v2.16.1
+  - FMS geos/2019.01.02+noaff.10 → geos/2019.01.02+noaff.11
 
 ## [2.29.0] - 2026-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.30.0] - 2026-03-12
+
+### Changed
+
+- Update `components.yaml` with bugfix for FV3 Standalone
+  - FVdycoreCubed_GridComp v2.15.0 → v2.16.0
+
 ## [2.29.0] - 2026-03-12
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.29.0
+  VERSION 2.30.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -55,7 +55,7 @@ FMS:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.16.0
+  tag: v2.16.1
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.17.0
+  tag: v5.21.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.73.0
+  tag: v3.75.0
   develop: develop
 
 ecbuild:
@@ -49,7 +49,7 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02+noaff.10
+  tag: geos/2019.01.02+noaff.11
   develop: geos/release/2019.01
 
 FVdycoreCubed_GridComp:


### PR DESCRIPTION
This updates fv3 gc to v2.16.1 with the fix from @FlorianDeconinck  https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/340

We also update ESMA_env, ESMA_cmake and ecbuild to match or exceed GEOSgcm `main` as of 2026-04-01