### PR TITLE
Update components to match GEOSgcm v11.9.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v8.24.0
+baselibs_version: &baselibs_version v8.27.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name fv3version
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build_fv3:
     strategy:
+      fail-fast: false
       matrix:
         compiler: [ifort, gfortran-14, gfortran-15]
         build-type: [Debug]
@@ -27,7 +28,6 @@ jobs:
     with:
       compiler: ${{ matrix.compiler }}
       cmake-build-type: ${{ matrix.build-type }}
-      fail-fast: false
       run-mepo-develop: false
 
   spack_build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.31.0] - 2026-05-29
+
+### Changed
+
+- Update `components.yaml` to match GEOSgcm v11.9.1
+  - ESMA_env v5.21.0 → v5.22.0
+  - GMAO_Shared v2.1.6 → v2.1.7
+  - GEOS_Util v2.1.12 → v2.1.17
+  - MAPL v2.67.0 → v2.69.1
+
 ## [2.30.0] - 2026-04-01
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSfvdycore
-  VERSION 2.30.0
+  VERSION 2.31.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -79,7 +79,7 @@ if (NOT Baselibs_FOUND)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
-  find_package(MAPL 2.67 QUIET)
+  find_package(MAPL 2.69 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ endif
 ```
 
 ##### NAS
+
 ```
 module use -a /nobackup/gmao_SIteam/modulefiles
 ```
 
 ##### GMAO Desktops
+
 On the GMAO desktops, the SI Team modulefiles should automatically be
 part of running `module avail` but if not, they are in:
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.21.0
+  tag: v5.22.0
   develop: main
 
 cmake:
@@ -22,14 +22,14 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v2.1.6
+  tag: v2.1.7
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.1.12
+  tag: v2.1.17
   develop: main
 
 GMAO_perllib:
@@ -43,7 +43,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.67.0
+  tag: v2.69.1
   develop: release/v2
 
 FMS:


### PR DESCRIPTION
As GEOSgcm is now almost at v12, we need to release one last "v11" like GEOSfvdycore